### PR TITLE
Fix: No categories on task edit

### DIFF
--- a/src/ui/dlg/taskdlg.cpp
+++ b/src/ui/dlg/taskdlg.cpp
@@ -665,14 +665,15 @@ void TaskDialog::DataToControls()
 
     if (pCfg->ShowProjectAssociatedCategories()) {
         ret = categoryRepo.FilterByProjectId(taskModel.ProjectId, categories);
-        if (ret == -1) {
-            std::string message = "Failed to get categories";
-            QueueErrorNotificationEventToParent(message);
-
-            isSuccess = false;
-        }
     } else {
         ret = categoryRepo.Filter(categories);
+    }
+
+    if (ret == -1) {
+        std::string message = "Failed to get categories";
+        QueueErrorNotificationEventToParent(message);
+
+        isSuccess = false;
     }
 
     if (!categories.empty()) {
@@ -684,23 +685,20 @@ void TaskDialog::DataToControls()
             pCategoryChoiceCtrl->Append(
                 category.GetFormattedName(), new ClientData<std::int64_t>(category.CategoryId));
         }
-    } else if (categories.empty() && !pCfg->ShowProjectAssociatedCategories()) {
-        if (!pCategoryChoiceCtrl->IsEnabled()) {
-            pCategoryChoiceCtrl->Enable();
+
+        repos::CategoryRepositoryModel category;
+        ret = categoryRepo.GetById(taskModel.CategoryId, category);
+        if (ret != 0) {
+            std::string message = "Failed to get category";
+            QueueErrorNotificationEventToParent(message);
+
+            isSuccess = false;
+        } else {
+            pCategoryChoiceCtrl->SetStringSelection(category.GetFormattedName());
+            isSuccess = true;
         }
     } else {
         ResetCategoryChoiceControl(true);
-    }
-
-    repos::CategoryRepositoryModel category;
-    ret = categoryRepo.GetById(taskModel.CategoryId, category);
-    if (ret != 0) {
-        std::string message = "Failed to get category";
-        QueueErrorNotificationEventToParent(message);
-        isSuccess = false;
-    } else {
-        pCategoryChoiceCtrl->SetStringSelection(category.GetFormattedName());
-        isSuccess = true;
     }
 
     if (isSuccess) {

--- a/src/ui/dlg/taskdlg.cpp
+++ b/src/ui/dlg/taskdlg.cpp
@@ -671,6 +671,8 @@ void TaskDialog::DataToControls()
 
             isSuccess = false;
         }
+    } else {
+        ret = categoryRepo.Filter(categories);
     }
 
     if (!categories.empty()) {


### PR DESCRIPTION
- No categories on task edit when "Only show associated categories" is not checked
- Check database return code for success
- Move fetching of category into success if branch